### PR TITLE
Truncate vectors explicitly

### DIFF
--- a/NoiseShader/HLSL/NoiseUtils.hlsl
+++ b/NoiseShader/HLSL/NoiseUtils.hlsl
@@ -74,7 +74,7 @@ float rand2dTo1d(float2 value, float2 dotDir = float2(12.9898, 78.233)){
 }
 
 float rand1dTo1d(float3 value, float mutator = 0.546){
-	float random = frac(sin(value + mutator) * 143758.5453);
+	float random = frac(sin(value.x + mutator) * 143758.5453);
 	return random;
 }
 

--- a/NoiseShader/HLSL/SimplexNoise3D.hlsl
+++ b/NoiseShader/HLSL/SimplexNoise3D.hlsl
@@ -184,7 +184,7 @@ void SimplexNoise3D_float(float3 input, out float Out)
 
 void SimplexNoise3DGradient_float(float3 input, out float Out)
 {
-    Out = snoise_grad(input);
+    Out = snoise_grad(input).x;
 }
 
 // END JIMMY'S MODIFICATIONS


### PR DESCRIPTION
Some shader warnings were being logged on compilation due to implicit truncation of vector type. Just some minor changes to remove those warnings by explicitly truncating the vectors.

Closes #19